### PR TITLE
Filter newline and carriage returns in GetClassList

### DIFF
--- a/src/HtmlAgilityPack.CssSelectors.NetCore/NodeExtensionMethods.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/NodeExtensionMethods.cs
@@ -16,7 +16,7 @@ namespace HtmlAgilityPack.CssSelectors.NetCore
             var attr = node.Attributes["class"];
             if (attr == null)
                 return new string[0];
-            return attr.Value.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            return attr.Value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public static int GetIndexOnParent(this HtmlNode node)

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
@@ -98,7 +98,12 @@ namespace HtmlAgilityPack.CssSelectors.NetCore.UnitTests
             Assert.IsTrue(text == "Hello World!");
         }
 
-
+        [TestMethod]
+        public void GetElementsByClassName_WithWhitespace()
+        {
+            var elements = Doc.QuerySelectorAll(".whitespace");
+            Assert.IsNotNull(elements.Count == 3);
+        }
 
         private static HtmlDocument LoadHtml()
         {

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
@@ -35,5 +35,20 @@
         <p><!-- comment 1 -->Hello</p>
         <p> <!-- comment 2 -->World!</p>
     </div>
+        <div class="
+
+             whitespace
+
+                "></div>
+        <div class="
+
+             whitespace
+
+                "></div>
+        <div class="
+
+             whitespace
+
+                "></div>
     </body>
 </html>


### PR DESCRIPTION
This fixes an issue with the class name selector within a call to QuerySelectorAll and an html element's class contains leading and trailing whitespace.