### PR TITLE
Add support for missing selector scenarios

### DIFF
--- a/src/HtmlAgilityPack.CssSelectors.NetCore/Selectors/AttributeSelector.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/Selectors/AttributeSelector.cs
@@ -56,6 +56,32 @@ namespace HtmlAgilityPack.CssSelectors.NetCore.Selectors
                 case '^': return (attr, v) => attr.StartsWith(v);
                 case '$': return (attr, v) => attr.EndsWith(v);
                 case '~': return (attr, v) => attr.Split(' ').Contains(v);
+
+                case '|':
+                    // This operator will only match if the first full-word in the attribute value
+                    // is either an exact match to the query or is an exact match immediately followed by a dash. 
+                    return (attr, v) =>
+                    {
+                        var isMatch = false;
+
+                        if (attr == v)
+                        {
+                            isMatch = true;
+                        }
+                        else if (attr.Length > v.Length)
+                        {
+                            var firstValue = attr
+                                .Split(new[] { ' ' }, StringSplitOptions.None)
+                                .FirstOrDefault();
+
+                            if (firstValue?.StartsWith(v) ?? false)
+                            {
+                                isMatch = firstValue.Length > v.Length && firstValue[v.Length] == '-';
+                            }
+                        }
+
+                        return isMatch;
+                    };
             }
 
             throw new NotSupportedException($"Invalid selector use for attribute {Selector}.");

--- a/src/HtmlAgilityPack.CssSelectors.NetCore/Token.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/Token.cs
@@ -31,10 +31,18 @@ namespace HtmlAgilityPack.CssSelectors.NetCore
             char closeBracket = '\0';
             for (int i = 0; i < token.Length; i++)
             {
-                if (isOpeningBracket && token[i] != closeBracket)
-                    continue;
+                if (isOpeningBracket)
+                {
+                    if (token[i] == closeBracket)
+                    {
+                        isOpeningBracket = false;
+                        isPrefix = true;
+                        rt.Add(token.Substring(start, i - start + 1));
+                        start = i + 1;
+                    }
 
-                isOpeningBracket = false;
+                    continue;
+                }
 
                 if (token[i] == '(')
                 {

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
@@ -99,6 +99,39 @@ namespace HtmlAgilityPack.CssSelectors.NetCore.UnitTests
         }
 
         [TestMethod]
+        public void GetElementsWithRelaxedStartsWithFilter()
+        {
+            var matches = Doc.QuerySelectorAll("#relaxed-starts-with-tests > p[class^=\"match\"]");
+            Assert.IsTrue(matches.Any() && matches.All(m => m.InnerText.Equals("Match")));
+            var mismatches = matches.First().ParentNode.ChildNodes.Where(n => n.Name == "p").Except(matches);
+            Assert.IsTrue(mismatches.Any() && mismatches.All(n => n.InnerText.Equals("NoMatch")));
+        }
+
+        [TestMethod]
+        public void GetElementsWithStrictStartsWithFilter()
+        {
+            var matches = Doc.QuerySelectorAll("#strict-starts-with-tests > p[class|=\"match\"]");
+            Assert.IsTrue(matches.Any() && matches.All(m => m.InnerText.Equals("Match")));
+            var mismatches = matches.First().ParentNode.ChildNodes.Where(n => n.Name == "p").Except(matches);
+            Assert.IsTrue(mismatches.Any() && mismatches.All(n => n.InnerText.Equals("NoMatch")));
+
+            // Test as well when te provided filter ends with a dash
+            matches = Doc.QuerySelectorAll("#strict-starts-with-tests-trailing-dash > p[class|=\"match-\"]");
+            Assert.IsTrue(matches.Any() && matches.All(m => m.InnerText.Equals("Match")));
+            mismatches = matches.First().ParentNode.ChildNodes.Where(n => n.Name == "p").Except(matches);
+            Assert.IsTrue(mismatches.Any() && mismatches.All(n => n.InnerText.Equals("NoMatch")));
+        }
+
+        [TestMethod]
+        public void GetElementsWithEndingBracketFollowedByClassName()
+        {
+            var matches = Doc.QuerySelectorAll("#ending-bracket-followed-by-class-test > a[href$=\".pdf\"].match");
+            Assert.IsTrue(matches.Any() && matches.All(m => m.InnerText.Equals("Match")));
+            var mismatches = matches.First().ParentNode.ChildNodes.Where(n => n.Name == "a").Except(matches);
+            Assert.IsTrue(mismatches.Any() && mismatches.All(n => n.InnerText.Equals("NoMatch")));
+        }
+
+        [TestMethod]
         public void GetElementsByClassName_WithWhitespace()
         {
             var elements = Doc.QuerySelectorAll(".whitespace");

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
@@ -31,10 +31,52 @@
                 </ul>
             </li>
         </ul>
-    <div id="with-comments">
-        <p><!-- comment 1 -->Hello</p>
-        <p> <!-- comment 2 -->World!</p>
-    </div>
+        <div id="relaxed-starts-with-tests">
+            <p class="match">Match</p>
+            <p class="match-1-2">Match</p>
+            <p class="match match1">Match</p>
+            <p class="match1 match2">Match</p>
+            <p class="Match">NoMatch</p>
+            <p class=" match">NoMatch</p>
+            <p class="m atch match">NoMatch</p>
+        </div>
+        <div id="strict-starts-with-tests">
+            <p class="match">Match</p>
+            <p class="match-1-2">Match</p>
+            <p class="match-1-2 other">Match</p>
+            <p class="Match">NoMatch</p>
+            <p class=" match">NoMatch</p>
+            <p class="match match1">NoMatch</p>
+            <p class="m atch match">NoMatch</p>
+            <p class="match1 match2">NoMatch</p>
+        </div>
+        <div id="strict-starts-with-tests-trailing-dash">
+            <p class="match-">Match</p>
+            <p class="match--1-2">Match</p>
+            <p class="match--1-2 other">Match</p>
+            <p class="match-1-2">NoMatch</p>
+            <p class="Match-">NoMatch</p>
+            <p class=" match-">NoMatch</p>
+            <p class="match- match--1">NoMatch</p>
+            <p class="m atch-- match--">NoMatch</p>
+            <p class="match-1 match-2">NoMatch</p>
+        </div>
+        <div id="ending-bracket-followed-by-class-test">
+            <a class="match" href="/path/file.pdf">Match</a>
+            <a class="match" href=".pdf">Match</a>
+            <a class="match" href="/path/file.pDf">NoMatch</a>
+            <a class="match" href=".pDf">NoMatch</a>
+            <a class="match" href="/path/file.pd">NoMatch</a>
+            <a class="nomatch" href="/path/file.pdf">NoMatch</a>
+            <a class="nomatch" href=".pdf">NoMatch</a>
+            <a class="nomatch" href="/path/file.pDf">NoMatch</a>
+            <a class="nomatch" href=".pDf">NoMatch</a>
+            <a class="nomatch" href="/path/file.pd">NoMatch</a>
+        </div>
+        <div id="with-comments">
+            <p><!-- comment 1 -->Hello</p>
+            <p> <!-- comment 2 -->World!</p>
+        </div>
         <div class="
 
              whitespace


### PR DESCRIPTION
Added support for the following selector scenarios:

1) string operator |
(slightly different behavior than operator ^)

2) additional tokens that appear after an ending bracket. This one was leading to an unhandled exception.

Added tests for these changes which serve as examples of the new selector formats that are enabled by these changes.