### PR TITLE
Fix asterisk sub-tokens, child scoping & nospaces edgecase

### DIFF
--- a/src/HtmlAgilityPack.CssSelectors.NetCore/ExtensionMethods.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/ExtensionMethods.cs
@@ -48,10 +48,23 @@ namespace HtmlAgilityPack.CssSelectors.NetCore
 
             bool allowTraverse = true;
 
-            foreach (var selector in selectors)
+            for (int i = 0; i < selectors.Count; i++)
             {
+                var selector = selectors[i];
+
                 if (allowTraverse && selector.AllowTraverse)
+                {
+                    // If this is not the first selector then we must make filter against the child nodes of the current set of nodes
+                    // since any selector that follows another selector always scopes down the nodes to the descendants of the last scope.
+                    // Example: "span span" Should only resolve with span elements that are descendants of another span element.
+                    // Any span elements that are not descendant of another span element shoud not be included in the output.
+                    if (i > 0)
+                    {
+                        nodes = nodes.SelectMany(n => n.ChildNodes);
+                    }
+
                     nodes = Traverse(nodes);
+                }
 
                 nodes = selector.Filter(nodes);
                 allowTraverse = selector.AllowTraverse;

--- a/src/HtmlAgilityPack.CssSelectors.NetCore/Token.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/Token.cs
@@ -22,7 +22,7 @@ namespace HtmlAgilityPack.CssSelectors.NetCore
 
         private static IList<string> SplitTokens(string token)
         {
-            Func<char, bool> isNameToken = (c) => char.IsLetterOrDigit(c) || c == '-'|| c == '_';
+            Func<char, bool> isNameToken = (c) => char.IsLetterOrDigit(c) || c == '-' || c == '_' || c == '*';
             var rt = new List<string>();
            
             int start = 0;

--- a/src/HtmlAgilityPack.CssSelectors.NetCore/Tokenizer.cs
+++ b/src/HtmlAgilityPack.CssSelectors.NetCore/Tokenizer.cs
@@ -43,7 +43,7 @@ namespace HtmlAgilityPack.CssSelectors.NetCore
 
                 char c = (char)v;
 
-                if (c == ' ' || c == '\t')
+                if (c == ' ' || c == '\t' || c == '>')
                     break;
 
                 sb.Append(c);

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
@@ -157,6 +157,19 @@ namespace HtmlAgilityPack.CssSelectors.NetCore.UnitTests
         }
 
         [TestMethod]
+        public void GetChildElementsOfTypeWithSpacelessSelector()
+        {
+            var matches = Doc.QuerySelectorAll("#selector-nospaces .class-name-1>p");
+            Assert.IsTrue(matches.Count() == 1 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+
+            matches = Doc.QuerySelectorAll("#selector-nospaces .class-name-1> p");
+            Assert.IsTrue(matches.Count() == 1 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+
+            matches = Doc.QuerySelectorAll("#selector-nospaces .class-name-1 >p");
+            Assert.IsTrue(matches.Count() == 1 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+        }
+
+        [TestMethod]
         public void GetElementsByClassName_WithWhitespace()
         {
             var elements = Doc.QuerySelectorAll(".whitespace");

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/QuerySelectorTest.cs
@@ -132,6 +132,31 @@ namespace HtmlAgilityPack.CssSelectors.NetCore.UnitTests
         }
 
         [TestMethod]
+        public void GetElementsOfTypeThatAreDescendantOfAnotherWithSameType()
+        {
+            var matches = Doc.QuerySelectorAll("#selector-nested-elements-same-type span span");
+            Assert.IsTrue(matches.Count() == 3 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+        }
+
+        [TestMethod]
+        public void GetAbsolutelyAllElements()
+        {
+            var matches = Doc.QuerySelectorAll("*");
+            Assert.IsTrue(matches.FirstOrDefault()?.Name.Equals("html") ?? false);
+            Assert.IsTrue(matches.Count() == Doc.DocumentNode.DescendantsAndSelf().Where(n => n.NodeType == HtmlNodeType.Element).Count());
+        }
+
+        [TestMethod]
+        public void GetElementsOfAnyTypeButWithMatchingClass()
+        {
+            var matches = Doc.QuerySelectorAll("#selector-asterisk-edgecase-1 *.class-name-1");
+            Assert.IsTrue(matches.Count() == 2 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+
+            matches = Doc.QuerySelectorAll("#selector-asterisk-edgecase-2 *.class-name-1 *");
+            Assert.IsTrue(matches.Count() == 3 && matches.All(m => m.InnerText.Trim().StartsWith("Match")));
+        }
+
+        [TestMethod]
         public void GetElementsByClassName_WithWhitespace()
         {
             var elements = Doc.QuerySelectorAll(".whitespace");

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
@@ -73,6 +73,52 @@
             <a class="nomatch" href=".pDf">NoMatch</a>
             <a class="nomatch" href="/path/file.pd">NoMatch</a>
         </div>
+        <div id="selector-nested-elements-same-type">
+            <span>
+                NoMatch
+                <span>
+                    Match
+                    <a>
+                        <span>
+                            Match
+                        </span>
+                    </a>
+                    <span>
+                        Match
+                    </span>
+                </span>
+            </span>
+            <div>
+                <span>NoMatch</span>
+            </div>
+            <span>NoMatch</span>
+        </div>
+        <div id="selector-asterisk-edgecase-1">
+            <div class="class-name-1">
+                Match
+                <span>NoMatch</span>
+                <span class="class-name-1">Match</span>
+                <span class="class-name-2">NoMatch</span>
+            </div>
+            <div class="class-name-2">
+                NoMatch
+                <span>NoMatch</span>
+            </div>
+            <span>NoMatch</span>
+        </div>
+        <div id="selector-asterisk-edgecase-2">
+            <div class="class-name-1">
+                NoMatch
+                <span>Match</span>
+                <span class="class-name-1">Match</span>
+                <span class="class-name-2">Match</span>
+            </div>
+            <div class="class-name-2">
+                NoMatch
+                <span>NoMatch</span>
+            </div>
+            <span>NoMatch</span>
+        </div>
         <div id="with-comments">
             <p><!-- comment 1 -->Hello</p>
             <p> <!-- comment 2 -->World!</p>

--- a/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
+++ b/test/HtmlAgilityPack.CssSelectors.NetCore.UnitTests/Test1.html
@@ -119,6 +119,19 @@
             </div>
             <span>NoMatch</span>
         </div>
+        <div id="selector-nospaces">
+            <div class="class-name-1">
+                NoMatch
+                <span>NoMatch</span>
+                <p>Match</p>
+                <span>NoMatch</span>
+            </div>
+            <div class="class-name-2">
+                NoMatch
+                <span>NoMatch</span>
+            </div>
+            <p>NoMatch</p>
+        </div>
         <div id="with-comments">
             <p><!-- comment 1 -->Hello</p>
             <p> <!-- comment 2 -->World!</p>


### PR DESCRIPTION
Fix edge cases with asterisk selectors, filter down to child nodes scopes for each selector level & properly handle token > when not preceeded by spaces. For example:

selector: *.class-name-1 *
This was not actually filtering by class at all, it was instead returning all elements (it only evaluated the asterisk and did not recognize the sub-tokens that were supposed to follow)

selector: span span
This was including all span elements even if they were not descendant of another span element

selector: .class-name1>p
This was returning all immediate children of .class-name1 without filtering elements of type 'p'. Notice this is an edge case where there are no spaces in between the class name and '>'